### PR TITLE
Allow all request headers for CORS

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -23,7 +23,7 @@ return [
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['Authorization', 'Content-Type'],
+    'allowed_headers' => ['*'],
 
     'exposed_headers' => [],
 


### PR DESCRIPTION
## Summary
- update the Laravel CORS configuration to allow any request headers so that preflight checks succeed for POST requests

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd720f432c8321aba9e0e8685d9f6e