### PR TITLE
Add backend subtree split workflow

### DIFF
--- a/.github/workflows/backend-subtree.yml
+++ b/.github/workflows/backend-subtree.yml
@@ -1,0 +1,36 @@
+name: Build Backend Subtree
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - backend/**
+  workflow_dispatch:
+
+jobs:
+  split-backend:
+    name: Split backend subtree
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create backend subtree branch
+        run: |
+          git branch -D deploy-backend 2>/dev/null || true
+          git subtree split --prefix=backend -b deploy-backend
+
+      - name: Push backend subtree branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin deploy-backend --force


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that rebuilds the backend subtree into the deploy-backend branch whenever backend/ changes on master
- ensure the workflow recreates the branch on each run and allows manual dispatches

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd789801588321a0161755317086f3