### PR TITLE
Add htaccess creation step to frontend deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      - name: Add .htaccess to build output
+        run: |
+          cat <<'EOF' > build/.htaccess
+          RewriteEngine On
+          RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+          RewriteBase /
+          RewriteRule ^index\.html$ - [L]
+          RewriteCond %{REQUEST_FILENAME} !-f
+          RewriteCond %{REQUEST_FILENAME} !-d
+          RewriteRule . /index.html [L]
+          EOF
+
       - name: Upload build to Cloudways via SFTP
         uses: wlixcc/SFTP-Deploy-Action@v1.2.4
         with:


### PR DESCRIPTION
## Summary
- add a workflow step that writes the required `.htaccess` file into the frontend build directory prior to deployment so Apache serves the SPA correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd7c1c6c248321aa5768996268b932