### PR TITLE
Set frontend build env vars in deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      REACT_APP_API_SERVER_URL: ${{ secrets.REACT_APP_API_SERVER_URL }}
+      REACT_APP_WEBSOCKET_SERVER_URL: ${{ secrets.REACT_APP_WEBSOCKET_SERVER_URL }}
 
     defaults:
       run:


### PR DESCRIPTION
## Summary
- expose the frontend API and websocket URLs to the build job so the CRA build picks up the expected values

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd7ff0cc6c8321866a38a0924e3e6f