### PR TITLE
Limit frontend deploy workflow to frontend changes

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - frontend/**
+      - .github/workflows/frontend-deploy.yml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict the frontend deploy workflow to run only when frontend files or the workflow itself change on master

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd839074f88321a7f2f6a899e347fb