### PR TITLE
Avoid showing non-admin dashboard during admin load

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import { Box, Card, Grid, Typography } from "@mui/material";
 import { Container } from "@mui/system";
 import React from "react";
 import { OverallResults } from "components/dashboard/OverallResults";
+import { Splashscreen } from "components/core/Splashscreen";
 import TomorrowSchedule from "../../components/dashboard/TomorrowSchedule/TomorrowSchedule";
 import TodaySchedule from "../../components/dashboard/TodaySchedule/TodaySchedule";
 import { useUser } from "hooks/user";
@@ -51,6 +52,10 @@ export const Dashboard = (): React.ReactElement => {
   const user = useUser();
 
   console.log(user);
+
+  if (user === undefined) {
+    return <Splashscreen />;
+  }
 
   return (
     <Box


### PR DESCRIPTION
## Summary
- show the splash screen on the dashboard until the current user record is loaded to prevent admins from seeing the student widgets during app startup

## Testing
- npm test -- --watchAll=false *(fails: Jest cannot parse ESM import from axios; existing test configuration needs to transform axios)*

------
https://chatgpt.com/codex/tasks/task_e_68cd72c89d2883219c66ec98f8d33789