### PR TITLE
Update backend workflow env setup

### DIFF
--- a/.github/workflows/backend-subtree.yml
+++ b/.github/workflows/backend-subtree.yml
@@ -9,6 +9,7 @@ on:
       - master
     paths:
       - backend/**
+      - .github/workflows/backend-subtree.yml
   workflow_dispatch:
 
 jobs:
@@ -21,6 +22,54 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Prepare backend environment file
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          CLIENT_ORIGIN_URL: ${{ secrets.CLIENT_ORIGIN_URL }}
+          PUSHER_APP_ID: ${{ secrets.PUSHER_APP_ID }}
+          PUSHER_APP_KEY: ${{ secrets.PUSHER_APP_KEY }}
+          PUSHER_APP_SECRET: ${{ secrets.PUSHER_APP_SECRET }}
+          DB_DATABASE: ${{ secrets.DB_DATABASE }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          APP_URL: ${{ secrets.APP_URL }}
+        run: |
+          cp backend/.env.example backend/.env
+          python - <<'PY'
+          import os
+
+          path = "backend/.env"
+          replacements = {
+              "APP_DEBUG": "false",
+              "JWT_SECRET": os.environ["JWT_SECRET"],
+              "CLIENT_ORIGIN_URL": os.environ["CLIENT_ORIGIN_URL"],
+              "PUSHER_APP_ID": os.environ["PUSHER_APP_ID"],
+              "PUSHER_APP_KEY": os.environ["PUSHER_APP_KEY"],
+              "PUSHER_APP_SECRET": os.environ["PUSHER_APP_SECRET"],
+              "DB_DATABASE": os.environ["DB_DATABASE"],
+              "DB_USERNAME": os.environ["DB_USERNAME"],
+              "DB_PASSWORD": os.environ["DB_PASSWORD"],
+              "APP_URL": os.environ["APP_URL"],
+          }
+
+          with open(path, "r", encoding="utf-8") as f:
+              lines = f.readlines()
+
+          with open(path, "w", encoding="utf-8") as f:
+              for original_line in lines:
+                  line = original_line.rstrip("\n")
+                  if not line or line.lstrip().startswith("#") or "=" not in line:
+                      f.write(original_line)
+                      continue
+
+                  key, value = line.split("=", 1)
+                  if key in replacements:
+                      replacement_value = replacements[key]
+                      f.write(f"{key}={replacement_value}\n")
+                  else:
+                      f.write(original_line)
+          PY
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
- copy the backend `.env.example` to `.env` during the workflow run and populate required values from repository secrets
- force `APP_DEBUG=false` in the generated environment file and map additional backend secrets used during builds
- ensure the backend workflow also runs when its workflow file changes

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cd86bdbe608321bc0c16dc8b644ca1