### PR TITLE
Ensure API responses always include CORS headers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -61,5 +61,7 @@ SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
 
 CLIENT_ORIGIN_URL=http://localhost:3000
+# Comma-separated list of allowed frontend origins (optional). If empty, CLIENT_ORIGIN_URL is used.
+CLIENT_ORIGIN_URLS=http://localhost:3000
 AUTH0_AUDIENCE=https://api.timebombmusic.it
 AUTH0_DOMAIN=dev-w1au7ftrmliawtii.us.auth0.com

--- a/backend/app/Http/Middleware/HttpHeaders.php
+++ b/backend/app/Http/Middleware/HttpHeaders.php
@@ -6,6 +6,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class HttpHeaders
 {
@@ -20,12 +21,77 @@ class HttpHeaders
     {
         $response = $next($request);
 
+        $this->ensureCorsHeaders($request, $response);
+
         $response->headers->add(config('headers.include'));
 
         foreach (config('headers.exclude') as $header) {
+            $response->headers->remove($header);
             header_remove($header);
         }
 
         return $response;
+    }
+
+    private function ensureCorsHeaders(Request $request, Response $response): void
+    {
+        if ($response->headers->has('Access-Control-Allow-Origin')) {
+            return;
+        }
+
+        $origin = $request->headers->get('Origin');
+
+        if ($origin === null || $origin === '') {
+            return;
+        }
+
+        if (!$this->originIsAllowed($origin)) {
+            return;
+        }
+
+        $response->headers->set('Access-Control-Allow-Origin', $origin);
+        $this->appendVaryHeader($response, 'Origin');
+
+        if (config('cors.supports_credentials', false) && !$response->headers->has('Access-Control-Allow-Credentials')) {
+            $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        }
+    }
+
+    private function originIsAllowed(string $origin): bool
+    {
+        $allowedOrigins = config('cors.allowed_origins', []);
+        $allowedPatterns = config('cors.allowed_origins_patterns', []);
+
+        if (in_array('*', $allowedOrigins, true)) {
+            return true;
+        }
+
+        if (in_array($origin, $allowedOrigins, true)) {
+            return true;
+        }
+
+        foreach ($allowedPatterns as $pattern) {
+            if ($pattern === '') {
+                continue;
+            }
+
+            $match = @preg_match($pattern, $origin);
+
+            if ($match === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function appendVaryHeader(Response $response, string $value): void
+    {
+        $existing = $response->headers->get('Vary');
+
+        $values = array_filter(array_map('trim', explode(',', (string) $existing)));
+        $values[] = $value;
+
+        $response->headers->set('Vary', implode(', ', array_unique($values)));
     }
 }

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -19,7 +19,46 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [env('CLIENT_ORIGIN_URL')],
+    'allowed_origins' => (static function () {
+        $rawOrigins = env('CLIENT_ORIGIN_URLS');
+
+        if (empty($rawOrigins)) {
+            $rawOrigins = env('CLIENT_ORIGIN_URL', '');
+        }
+
+        if (!is_string($rawOrigins)) {
+            $rawOrigins = '';
+        }
+
+        $candidates = preg_split('/[\s,]+/', $rawOrigins, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $origins = [];
+
+        foreach ($candidates as $candidate) {
+            $candidate = trim($candidate);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            if ($candidate !== '*') {
+                $candidate = rtrim($candidate, '/');
+            }
+
+            $origins[] = $candidate;
+        }
+
+        $origins = array_values(array_unique($origins));
+
+        if (empty($origins)) {
+            $origins = [
+                'http://localhost:3000',
+                'https://app.timebombmusic.it',
+            ];
+        }
+
+        return $origins;
+    })(),
 
     'allowed_origins_patterns' => [],
 


### PR DESCRIPTION
## Summary
- normalise the configured CORS origins so environment values with whitespace or trailing slashes still match requests and fall back to known defaults when unset
- ensure the custom HttpHeaders middleware attaches the Access-Control-Allow-Origin header (and related metadata) for allowed origins even when the framework middleware fails to do so

## Testing
- php -l backend/app/Http/Middleware/HttpHeaders.php
- php -l backend/config/cors.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8ae9029483219ad00f68b336a7cd