### PR TITLE
Add admin user impersonation support

### DIFF
--- a/backend/app/Helpers/user_helper.php
+++ b/backend/app/Helpers/user_helper.php
@@ -4,18 +4,47 @@ function jwt_decode($token) {
     return json_decode(base64_decode(str_replace('_', '/', str_replace('-','+',explode('.', $token)[1]))), true);
 }
 
+function get_jwt_payload(): array {
+    $header = $_SERVER['HTTP_AUTHORIZATION'] ?? null;
+
+    if (!$header) {
+        return [];
+    }
+
+    $parts = explode(' ', $header);
+
+    if (count($parts) < 2 || strtolower($parts[0]) !== 'bearer') {
+        return [];
+    }
+
+    $token = $parts[1];
+
+    if (!$token) {
+        return [];
+    }
+
+    return jwt_decode($token) ?? [];
+}
+
 function get_user_id() {
-    $header = $_SERVER['HTTP_AUTHORIZATION'];
+    $user_info = get_jwt_payload();
 
-    $token = explode(" ", $header)[1];
+    return $user_info['sub'] ?? null;
+}
 
-    $user_info = jwt_decode($token);
+function get_impersonator_id() {
+    $payload = get_jwt_payload();
 
-    return $user_info['sub'];
+    return $payload['impersonator_id'] ?? null;
 }
 
 function get_user_by_auth_header() {
     $user_id = get_user_id();
+
+    if (!$user_id) {
+        return null;
+    }
+
     $user = \App\Models\User::firstWhere('id', $user_id);
 
     return $user;

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -25,6 +25,7 @@ Route::group(['middleware' => 'auth:api'], function () {
     Route::put('user/change-password', [UserController::class, 'changePassword'])->name('changePassword');
     Route::get('user/current', [UserController::class, 'getCurrentUser'])->name('getCurrentUser');
     Route::post('/upload-avatar', [UserController::class, 'uploadAvatar'])->name('uploadAvatar');
+    Route::post('user/stop-impersonation', [UserController::class, 'stopImpersonation'])->name('stopImpersonation');
 
     Route::get('thread/all', [ChatController::class, 'getThreads'])->name('getThreads');
     Route::get('thread/{id}', [ChatController::class, 'getThread'])->name('getThread');
@@ -53,6 +54,7 @@ Route::group(['middleware' => ['auth:api', 'is_admin']], function () {
     Route::get('user/all', [UserController::class, 'getAllUsers'])->name('getAllUsers');
     Route::get('user/{id}', [UserController::class, 'getUser'])->name('getUser');
     Route::put('user/{id}', [UserController::class, 'updateUser'])->name('updateUser');
+    Route::post('user/{id}/impersonate', [UserController::class, 'impersonate'])->name('impersonateUser');
     Route::get('todos/all', [TodoController::class, 'getAllTodos'])->name('getAllTodos');
 });
 

--- a/frontend/src/components/layout/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout/AppLayout.tsx
@@ -3,8 +3,10 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { styled } from "@mui/material/styles";
 import { Sidebar } from "components/layout/Sidebar";
-import { Box } from "@mui/material";
+import { Alert, Box, Button, Typography } from "@mui/material";
 import { Navbar } from "components/layout/Navbar";
+import { useAuth } from "contexts/jwt-provider";
+import toast from "react-hot-toast";
 
 interface DashboardLayoutProps {
   children?: ReactNode;
@@ -23,6 +25,18 @@ const AppLayoutRoot = styled("div")(({ theme }) => ({
 export const AppLayout: FC<DashboardLayoutProps> = (props) => {
   const { children } = props;
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
+  const { user, stopImpersonation } = useAuth();
+
+  const handleStopImpersonation = async () => {
+    const { success, error } = await stopImpersonation();
+
+    if (!success) {
+      toast.error(error ?? "Impossibile tornare all'amministratore.");
+      return;
+    }
+
+    toast.success("Accesso come amministratore ripristinato.");
+  };
 
   return (
     <>
@@ -35,6 +49,27 @@ export const AppLayout: FC<DashboardLayoutProps> = (props) => {
             width: "100%",
           }}
         >
+          {user?.impersonator && (
+            <Alert
+              severity="warning"
+              sx={{
+                borderRadius: 0,
+                alignItems: "center",
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 2,
+              }}
+              action={
+                <Button color="inherit" size="small" onClick={handleStopImpersonation}>
+                  Torna a {user.impersonator.name || user.impersonator.email}
+                </Button>
+              }
+            >
+              <Typography variant="body2">
+                Stai impersonando {user.name || user.email}
+              </Typography>
+            </Alert>
+          )}
           {children}
         </Box>
       </AppLayoutRoot>

--- a/frontend/src/components/layout/Navbar/AccountPopover.tsx
+++ b/frontend/src/components/layout/Navbar/AccountPopover.tsx
@@ -11,9 +11,10 @@ import {
 } from "@mui/material";
 import LogoutIcon from "@mui/icons-material/Logout";
 import PersonIcon from "@mui/icons-material/Person";
+import SwitchAccountIcon from "@mui/icons-material/SwitchAccount";
 import { useAuth } from "contexts/jwt-provider";
 import React from "react";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 interface AccountPopoverProps {
   anchorEl: null | Element;
@@ -23,7 +24,7 @@ interface AccountPopoverProps {
 
 export const AccountPopover: FC<AccountPopoverProps> = (props) => {
   const { anchorEl, onClose, open, ...other } = props;
-  const { logout } = useAuth();
+  const { logout, stopImpersonation, user } = useAuth();
 
   const navigate = useNavigate();
 
@@ -39,6 +40,23 @@ export const AccountPopover: FC<AccountPopoverProps> = (props) => {
     } catch (err) {
       console.error(err);
       toast.error("Unable to logout.");
+    }
+  };
+
+  const handleStopImpersonation = async (): Promise<void> => {
+    try {
+      onClose?.();
+      const { success, error } = await stopImpersonation();
+
+      if (!success) {
+        toast.error(error ?? "Impossibile tornare all'amministratore.");
+        return;
+      }
+
+      toast.success("Accesso come amministratore ripristinato.");
+    } catch (err) {
+      console.error(err);
+      toast.error("Impossibile tornare all'amministratore.");
     }
   };
 
@@ -121,6 +139,25 @@ export const AccountPopover: FC<AccountPopoverProps> = (props) => {
         </Link>
         <Divider />
         */}
+        {user?.impersonator && (
+          <MenuItem onClick={handleStopImpersonation}>
+            <ListItemIcon>
+              <SwitchAccountIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText
+              primary={
+                <Typography variant="body1" sx={{ color: "white" }}>
+                  Torna a {user.impersonator.name || user.impersonator.email}
+                </Typography>
+              }
+              secondary={
+                <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.7)" }}>
+                  Stai impersonando {user.name || user.email}
+                </Typography>
+              }
+            />
+          </MenuItem>
+        )}
         <MenuItem onClick={handleProfile}>
           <ListItemIcon>
             <PersonIcon fontSize="small" />

--- a/frontend/src/components/users/UsersListTable/UsersListTable.tsx
+++ b/frontend/src/components/users/UsersListTable/UsersListTable.tsx
@@ -30,6 +30,7 @@ interface UserListTableProps {
   onRowsPerPageChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   page: number;
   rowsPerPage: number;
+  onImpersonate?: (userId: number) => void;
 }
 
 export const UsersListTable: FC<UserListTableProps> = (props) => {
@@ -40,6 +41,7 @@ export const UsersListTable: FC<UserListTableProps> = (props) => {
     onRowsPerPageChange,
     page,
     rowsPerPage,
+    onImpersonate,
     ...other
   } = props;
 
@@ -146,11 +148,29 @@ export const UsersListTable: FC<UserListTableProps> = (props) => {
                     </Box>
                   </TableCell>
                   <TableCell align="right">
-                    <Link to={"/users/" + user.id + "/edit"}>
-                      <IconButton component="h2">
-                        <PencilAltIcon fontSize="small" />
-                      </IconButton>
-                    </Link>
+                    <Box
+                      sx={{
+                        alignItems: "center",
+                        display: "flex",
+                        gap: 1,
+                        justifyContent: "flex-end",
+                      }}
+                    >
+                      {onImpersonate && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => onImpersonate(user.id)}
+                        >
+                          Impersona
+                        </Button>
+                      )}
+                      <Link to={"/users/" + user.id + "/edit"}>
+                        <IconButton component="h2">
+                          <PencilAltIcon fontSize="small" />
+                        </IconButton>
+                      </Link>
+                    </Box>
                   </TableCell>
                 </TableRow>
               );

--- a/frontend/src/hooks/user/useUser.ts
+++ b/frontend/src/hooks/user/useUser.ts
@@ -1,29 +1,37 @@
 import { useEffect, useState } from "react";
-import { User } from "types/User";
+import { CurrentUser } from "types/User";
 import { useAuth } from "contexts/jwt-provider";
 import { getCurrentUser } from "services/user.service";
 
-type UseUserReturnType = User | undefined;
+type UseUserReturnType = CurrentUser | undefined;
 
-let cached_user: User | undefined = undefined;
+let cached_user: CurrentUser | undefined = undefined;
 
 export const useUser = (): UseUserReturnType => {
-  const [user, setUser] = useState<User | undefined>(cached_user);
-  const { getAccessTokenSilently } = useAuth();
+  const [user, setUser] = useState<CurrentUser | undefined>(cached_user);
+  const { getAccessTokenSilently, user: authUser } = useAuth();
 
   useEffect(() => {
-    if (cached_user) {
+    if (!authUser) {
+      cached_user = undefined;
+      setUser(undefined);
+      return;
+    }
+
+    if (cached_user && cached_user.id === authUser.id) {
+      setUser(cached_user);
       return;
     }
 
     (async () => {
       const accessToken = await getAccessTokenSilently();
       const _user = await getCurrentUser({ accessToken });
+      const currentUser = _user.data as CurrentUser;
 
-      setUser(_user.data as User);
-      cached_user = _user.data;
+      setUser(currentUser);
+      cached_user = currentUser;
     })();
-  }, [getAccessTokenSilently, setUser, user]);
+  }, [authUser?.id, getAccessTokenSilently]);
 
   return user;
 };

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -24,6 +24,7 @@ import { User } from "types/User";
 import { createUser, getAllUsers } from "services/user.service";
 import { useAuth } from "contexts/jwt-provider";
 import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
 
 interface Filters {
   query?: string;
@@ -74,7 +75,8 @@ export const Users = (): React.ReactElement => {
     password: "",
   });
 
-  const { getAccessTokenSilently } = useAuth();
+  const { getAccessTokenSilently, impersonate, user: authUser } = useAuth();
+  const navigate = useNavigate();
 
   const queryRef = useRef<HTMLInputElement | null>(null);
   const filteredUsers = applyFilters(users, filters);
@@ -166,6 +168,23 @@ export const Users = (): React.ReactElement => {
     setRowsPerPage(parseInt(event.target.value, 10));
   };
 
+  const handleImpersonateUser = async (userId: number) => {
+    if (authUser?.id === userId) {
+      toast.error("Sei già autenticato come questo utente.");
+      return;
+    }
+
+    const { success, error } = await impersonate(userId);
+
+    if (!success) {
+      toast.error(error ?? "Impossibile impersonare l'utente selezionato.");
+      return;
+    }
+
+    toast.success("Stai impersonando l'utente selezionato.");
+    navigate("/");
+  };
+
   const handlePageChange = (
     event: MouseEvent<HTMLButtonElement> | null,
     newPage: number
@@ -238,6 +257,7 @@ export const Users = (): React.ReactElement => {
             onRowsPerPageChange={handleRowsPerPageChange}
             rowsPerPage={rowsPerPage}
             page={page}
+            onImpersonate={handleImpersonateUser}
           />
         </Card>
       </Container>

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -27,6 +27,15 @@ type ChangePasswordParams = {
   confirmNewPassword: string;
 };
 
+type ImpersonateUserParams = {
+  accessToken: string;
+  userId: number;
+};
+
+type StopImpersonationParams = {
+  accessToken: string;
+};
+
 export const getCurrentUser = async ({
   accessToken,
 }: GetCurrentUserParams): Promise<ApiResponse> => {
@@ -160,6 +169,47 @@ export const changePassword = async ({
       current_password: currentPassword,
       new_password: newPassword,
       new_password_confirmation: confirmNewPassword, // This should match the 'confirmed' validation rule in Laravel
+    },
+  };
+
+  const { data, error } = await callExternalApi({ config });
+
+  return {
+    data,
+    error,
+  };
+};
+
+export const impersonateUser = async ({
+  accessToken,
+  userId,
+}: ImpersonateUserParams): Promise<ApiResponse> => {
+  const config: AxiosRequestConfig = {
+    url: `${apiServerUrl}/user/${userId}/impersonate`,
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const { data, error } = await callExternalApi({ config });
+
+  return {
+    data,
+    error,
+  };
+};
+
+export const stopImpersonation = async ({
+  accessToken,
+}: StopImpersonationParams): Promise<ApiResponse> => {
+  const config: AxiosRequestConfig = {
+    url: `${apiServerUrl}/user/stop-impersonation`,
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
     },
   };
 

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -9,3 +9,13 @@ export interface User {
   is_admin: boolean;
   todos?: Todo[];
 }
+
+export interface ImpersonatorInfo {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface CurrentUser extends User {
+  impersonator?: ImpersonatorInfo | null;
+}


### PR DESCRIPTION
## Summary
- add backend helpers and routes so admins can impersonate users and revert to their original identity
- extend the JWT context, user services, and types to manage impersonation tokens on the frontend
- update admin screens and navigation UI to trigger impersonation and provide a quick way to switch back

## Testing
- php artisan test *(fails: missing vendor autoload because locked packages require PHP 8.1/8.2)*
- composer install *(fails: lcobucci/clock requires PHP ~8.1.0 || ~8.2.0)*
- CI=true npm test -- --watchAll=false *(fails: Jest cannot parse axios ESM import without custom transform)*

------
https://chatgpt.com/codex/tasks/task_e_68d0216b0ccc83218ba17ea0eeeb6d39