### PR TITLE
Fix useUser hook dependency usage

### DIFF
--- a/frontend/src/hooks/user/useUser.ts
+++ b/frontend/src/hooks/user/useUser.ts
@@ -10,15 +10,16 @@ let cached_user: CurrentUser | undefined = undefined;
 export const useUser = (): UseUserReturnType => {
   const [user, setUser] = useState<CurrentUser | undefined>(cached_user);
   const { getAccessTokenSilently, user: authUser } = useAuth();
+  const authUserId = authUser?.id;
 
   useEffect(() => {
-    if (!authUser) {
+    if (!authUserId) {
       cached_user = undefined;
       setUser(undefined);
       return;
     }
 
-    if (cached_user && cached_user.id === authUser.id) {
+    if (cached_user && cached_user.id === authUserId) {
       setUser(cached_user);
       return;
     }
@@ -31,7 +32,7 @@ export const useUser = (): UseUserReturnType => {
       setUser(currentUser);
       cached_user = currentUser;
     })();
-  }, [authUser?.id, getAccessTokenSilently]);
+  }, [authUserId, getAccessTokenSilently]);
 
   return user;
 };


### PR DESCRIPTION
## Summary
- derive the authenticated user's id before the effect to satisfy the hooks linter
- keep the cached user logic keyed by the id while avoiding unnecessary refetches

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d029b0be588321ac325148d9d113e1