### PR TITLE
Normalize impersonated user state

### DIFF
--- a/frontend/src/contexts/jwt-provider.tsx
+++ b/frontend/src/contexts/jwt-provider.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { getCurrentUser, impersonateUser, stopImpersonation } from "../services/user.service";
 import { CurrentUser, ImpersonatorInfo } from "types/User";
+import { normalizeCurrentUser } from "utils/normalize-current-user";
 
 // Login function
 const login = async (email: string, password: string) => {
@@ -65,6 +66,7 @@ interface AuthUser {
   email: string;
   is_admin: boolean;
   impersonator: ImpersonatorInfo | null;
+  isImpersonating: boolean;
 }
 
 interface JWTContextType {
@@ -118,14 +120,17 @@ export const JWTProvider: React.FC<JWTProviderProps> = ({ children }) => {
 
         const currentUser = response.data as CurrentUser;
 
+        const normalizedUser = normalizeCurrentUser(currentUser);
+
         setUser({
           token,
-          id: currentUser.id,
-          avatar: currentUser.avatar,
-          name: currentUser.name,
-          email: currentUser.email,
-          is_admin: currentUser.is_admin,
-          impersonator: currentUser.impersonator ?? null,
+          id: normalizedUser.id,
+          avatar: normalizedUser.avatar,
+          name: normalizedUser.name,
+          email: normalizedUser.email,
+          is_admin: normalizedUser.is_admin,
+          impersonator: normalizedUser.impersonator ?? null,
+          isImpersonating: normalizedUser.isImpersonating ?? false,
         });
       })
       .catch(() => {

--- a/frontend/src/hooks/use.ts
+++ b/frontend/src/hooks/use.ts
@@ -25,6 +25,8 @@ export const use: { useChat: ReturnType<typeof useChat>, useUser: ReturnType<typ
     name: '',
     id: 0,
     is_admin: false,
-    auth0_id: ''
+    auth0_id: '',
+    impersonator: null,
+    isImpersonating: false,
   }
 };

--- a/frontend/src/hooks/user/useUser.ts
+++ b/frontend/src/hooks/user/useUser.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { CurrentUser } from "types/User";
 import { useAuth } from "contexts/jwt-provider";
 import { getCurrentUser } from "services/user.service";
+import { normalizeCurrentUser } from "utils/normalize-current-user";
 
 type UseUserReturnType = CurrentUser | undefined;
 
@@ -28,9 +29,10 @@ export const useUser = (): UseUserReturnType => {
       const accessToken = await getAccessTokenSilently();
       const _user = await getCurrentUser({ accessToken });
       const currentUser = _user.data as CurrentUser;
+      const normalizedUser = normalizeCurrentUser(currentUser);
 
-      setUser(currentUser);
-      cached_user = currentUser;
+      setUser(normalizedUser);
+      cached_user = normalizedUser;
     })();
   }, [authUserId, getAccessTokenSilently]);
 

--- a/frontend/src/types/User.ts
+++ b/frontend/src/types/User.ts
@@ -18,4 +18,5 @@ export interface ImpersonatorInfo {
 
 export interface CurrentUser extends User {
   impersonator?: ImpersonatorInfo | null;
+  isImpersonating?: boolean;
 }

--- a/frontend/src/utils/normalize-current-user.ts
+++ b/frontend/src/utils/normalize-current-user.ts
@@ -1,0 +1,13 @@
+import { CurrentUser } from "types/User";
+
+export const normalizeCurrentUser = (user: CurrentUser): CurrentUser => {
+  const impersonator = user.impersonator ?? null;
+  const isImpersonating = Boolean(impersonator);
+
+  return {
+    ...user,
+    impersonator,
+    isImpersonating,
+    is_admin: isImpersonating ? false : user.is_admin,
+  };
+};


### PR DESCRIPTION
## Summary
- add a helper to normalize impersonated user data so admin privileges are disabled while acting as another user
- update the auth context and user hook to use the normalized data and expose the impersonation flag to the rest of the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03839cb948321807cf497a55cd73d